### PR TITLE
chore: set resources limits/requests

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -15,7 +15,10 @@ components:
         - exposure: public
           name: nodejs
           targetPort: 8080
-      memoryLimit: 1G
+      memoryLimit: '1Gi'
+      memoryRequest: '512Mi'
+      cpuLimit: '2'
+      cpuRequest: '1'
       mountSources: true
       volumeMounts:
         - name: npm
@@ -39,7 +42,10 @@ components:
         - name: mongodb
           exposure: internal
           targetPort: 27017
-      memoryLimit: 512Mi
+      memoryLimit: '512Mi'
+      memoryRequest: '256Mi'
+      cpuLimit: '1'
+      cpuRequest: '250m'
       mountSources: false
       volumeMounts:
         - name: mongo-storage

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -45,7 +45,7 @@ components:
       memoryLimit: '512Mi'
       memoryRequest: '256Mi'
       cpuLimit: '1'
-      cpuRequest: '250m'
+      cpuRequest: '0.25'
       mountSources: false
       volumeMounts:
         - name: mongo-storage


### PR DESCRIPTION
Set resources requests/limits:
nodejs container
```
      memoryLimit: '1Gi'
      memoryRequest: '512Mi'
      cpuLimit: '2'
      cpuRequest: '1'
```
mongodb container
```
      memoryLimit: '512Mi'
      memoryRequest: '256Mi'
      cpuLimit: '1'
      cpuRequest: '250m'
```
![screenshot-devspaces apps sandbox-m4 g2pi p1 openshiftapps com-2023 07 28-11_52_15](https://github.com/devspaces-samples/nodejs-mongodb-sample/assets/1271546/8874eef5-640f-44ae-a84d-d5c7f8e6ebd1)


Related issue: https://issues.redhat.com/browse/CRW-4611