### PR TITLE
chore: set resources limits/requests

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -15,7 +15,10 @@ components:
         - exposure: public
           name: nodejs
           targetPort: 8080
-      memoryLimit: 1G
+      memoryLimit: '1Gi'
+      memoryRequest: '512Mi'
+      cpuLimit: '2'
+      cpuRequest: '1'
       mountSources: true
       volumeMounts:
         - name: npm
@@ -39,7 +42,10 @@ components:
         - name: mongodb
           exposure: internal
           targetPort: 27017
-      memoryLimit: 512Mi
+      memoryLimit: '512Mi'
+      memoryRequest: '256Mi'
+      cpuLimit: '1'
+      cpuRequest: '250m'
       mountSources: false
       volumeMounts:
         - name: mongo-storage

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -45,7 +45,7 @@ components:
       memoryLimit: '512Mi'
       memoryRequest: '256Mi'
       cpuLimit: '1'
-      cpuRequest: '250m'
+      cpuRequest: '0.25'
       mountSources: false
       volumeMounts:
         - name: mongo-storage


### PR DESCRIPTION
Backporting https://github.com/devspaces-samples/nodejs-mongodb-sample/pull/31 to DS 3.8

Set resources requests/limits:
nodejs container
```
      memoryLimit: '1Gi'
      memoryRequest: '512Mi'
      cpuLimit: '2'
      cpuRequest: '1'
```
mongodb container
```
      memoryLimit: '512Mi'
      memoryRequest: '256Mi'
      cpuLimit: '1'
      cpuRequest: '250m'
```

Related issue: https://issues.redhat.com/browse/CRW-4611