### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -15,6 +15,7 @@ components:
         - exposure: public
           name: nodejs
           targetPort: 8080
+          protocol: https
       memoryLimit: '1Gi'
       memoryRequest: '512Mi'
       cpuLimit: '2'


### PR DESCRIPTION
Use https protocol in endpoint

![screenshot-devspaces apps sandbox-m4 g2pi p1 openshiftapps com-2023 12 21-15_05_01](https://github.com/devspaces-samples/nodejs-mongodb-sample/assets/1271546/c1ed8e33-835e-4c06-b241-0d589a558637)


Related issue: https://issues.redhat.com/browse/CRW-5377